### PR TITLE
Use mkdirp package instead of OS dependent cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,26 +5,21 @@
   "main": "index.js",
   "scripts": {
     "clean": "rm -rf src/_book build",
-    "start": "mkdir -p src/_book && npm run doc:serve",
+    "start": "mkdirp src/_book && npm run doc:serve",
     "test": "npm run build:html",
-
     "check:calibre": "(which calibre > /dev/null 2>&1) || (echo 'calibre not installed' && false)",
     "check:zip": "(which zip > /dev/null 2>&1) || (echo 'zip not installed' && false)",
-
     "doc:help": "gitbook help",
     "doc:serve": "gitbook serve src",
     "doc:init": "gitbook init src",
     "doc:build": "gitbook build src build/geoext3-ws",
     "doc:epub": "npm run check:calibre && gitbook epub src build/geoext3-ws.epub",
     "doc:pdf": "npm run check:calibre && gitbook pdf src build/geoext3-ws.pdf",
-
     "build:html": "npm run clean && npm run doc:build",
     "build:all": "npm run build:html && npm run doc:pdf && npm run doc:epub",
-
     "build:covers": "npm run build:cover && npm run build:cover_small",
     "build:cover": "svgexport src/cover.svg src/cover.jpg 95% 'svg{background: #fff;}'",
     "build:cover_small": "svgexport src/cover_small.svg src/cover_small.jpg 100% 'svg{background: #fff;}'",
-
     "archive": "npm run check:zip && npm run build:all && cd build && zip -r geoext3-ws.zip geoext3-ws *.epub *.pdf",
     "postinstall": "gitbook install src"
   },
@@ -48,5 +43,8 @@
   "devDependencies": {
     "gitbook-cli": "0.3.6",
     "svgexport": "0.2.8"
+  },
+  "dependencies": {
+    "mkdirp": "0.5.1"
   }
 }


### PR DESCRIPTION
This is an attempt to become more independent of the operating system. 

Hey @chrismayer @sullianmccornic, this might fix #2, it'd be extra nice if you could test this.

Fixes #2
