### PR TITLE
Introduce node script to add folders in npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "clean": "rm -rf src/_book build",
-    "start": "mkdir -p src/_book && npm run doc:serve",
+    "start": "node scripts/setup.js && npm run doc:serve",
     "test": "npm run build:html",
 
     "check:calibre": "(which calibre > /dev/null 2>&1) || (echo 'calibre not installed' && false)",
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/geoext/geoext3-ws#readme",
   "devDependencies": {
     "gitbook-cli": "0.3.6",
-    "svgexport": "0.2.8"
+    "svgexport": "0.2.8",
+    "mkdirp": "0.5.1"
   }
 }

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,9 @@
+var mkdirp = require('mkdirp');
+
+mkdirp('src/_book', function (err) {
+    if (err) {
+        console.error('Could not create the folder "src/_book"', err);
+    } else {
+        console.log('Folder "src/_book" created');
+    }
+});


### PR DESCRIPTION
This adds a node.js script to make the 'mkdir' command in the npm start process also runnable on non-Linux systems (Used [mkdirp](https://www.npmjs.com/package/mkdirp) package for this).
Fixes #2.
