### PR TITLE
use markdown link formats for example links.

### DIFF
--- a/src/feature-grid/prepare-layout.md
+++ b/src/feature-grid/prepare-layout.md
@@ -86,7 +86,7 @@ Ext.onReady(function(){
 </html>
 ```
 
-* If you open this file in a browser ({{ book.exerciseUrl }}/map.html), the application should look like in the following image:
+* If you open this file in a browser ([{{ book.exerciseUrl }}/map.html]({{ book.exerciseUrl }}/map.html)), the application should look like in the following image:
 
 ![Our starting point](before.png)
 

--- a/src/first-steps/hello-exercise.md
+++ b/src/first-steps/hello-exercise.md
@@ -15,7 +15,7 @@ If you e.g. store a file named `map.html` inside this directory, and you are
 serving the workshop as recommended, than this file can be accessed via the
 following URL:
 
-{{ book.exerciseUrl }}/map.html
+[{{ book.exerciseUrl }}/map.html]({{ book.exerciseUrl }}/map.html)
 
 Shall we tackle our first tiny excercise? Ok then, here we go:
 
@@ -38,11 +38,11 @@ Shall we tackle our first tiny excercise? Ok then, here we go:
 ```
 
 * See if your file is available in a browser under the following URL:
-  {{ book.exerciseUrl }}/my-exercise.html
+  [{{ book.exerciseUrl }}/my-exercise.html]({{ book.exerciseUrl }}/my-exercise.html)
 * In the body of the HTML change the content of the first `<h1>`-element to
   read: `GeoExt rocks!`
 * Check if any changes to the HTML file are reflected in your browser. Reload
-  the URL  {{ book.exerciseUrl }}/my-exercise.html
+  the URL  [{{ book.exerciseUrl }}/my-exercise.html]({{ book.exerciseUrl }}/my-exercise.html)
 
 If everything worked, you should see something like in the following images.
 
@@ -54,7 +54,7 @@ If everything worked, you should see something like in the following images.
 >
 > In case you added more files (e.g.for upcoming tasks) to the
 > `src/exercise/` folder and they are *not* instantly available under the
-> URL {{ book.exerciseUrl }}/filename.html
+> URL [{{ book.exerciseUrl }}/filename.html]({{ book.exerciseUrl }}/filename.html)
 >
 > … then you have to stop and start the fileserving again. See the
 > [notes on starting / stopping](../meta/development-environment.md)

--- a/src/first-steps/hello-extjs.md
+++ b/src/first-steps/hello-extjs.md
@@ -33,7 +33,7 @@ Again we'll need to include two resources in a HTML page to be able to use ExtJS
   <script src="path/to/file.js"></script>
   ```
 
-* Verify that {{ book.exerciseUrl }}/ext-example.html loads your file.
+* Verify that [{{ book.exerciseUrl }}/ext-example.html]({{ book.exerciseUrl }}/ext-example.html) loads your file.
 * Does your basic page look like the one in the following image? Why does the font look so different?
 
 ![The template-HTML with the ExtJS resources included](hello-ext.png)

--- a/src/first-steps/hello-geoext.md
+++ b/src/first-steps/hello-geoext.md
@@ -44,7 +44,7 @@ Ext.onReady(function(){
 
 * Most GeoExt components don't need special CSS. If you use the `Popup`-components, you may want to include the following CSS file: `http://geoext.github.io/geoext3/master/resources/css/gx-popup.css`
 
-* Verify that {{ book.exerciseUrl }}/hello-geoext.html loads in your browser
+* Verify that [{{ book.exerciseUrl }}/hello-geoext.html]({{ book.exerciseUrl }}/hello-geoext.html) loads in your browser
 
 # Adding our first GeoExt component
 

--- a/src/first-steps/hello-openlayers.md
+++ b/src/first-steps/hello-openlayers.md
@@ -32,7 +32,7 @@ Let's see how we can include OpenLayers in our page so that we can start to use 
 <script src="path/to/file.js"></script>
 ```
 
-* Verify that {{ book.exerciseUrl }}/ol-example.html loads your file.
+* Verify that [{{ book.exerciseUrl }}/ol-example.html]({{ book.exerciseUrl }}/ol-example.html) loads your file.
 
 * In the `<body>` of the file, add the following HTML-fragment, which includes a tiny bit of JavaScript:
 
@@ -54,7 +54,7 @@ Let's see how we can include OpenLayers in our page so that we can start to use 
 </script>
 ```
 
-* When you now reload the {{ book.exerciseUrl }}/ol-example.html URL, you should see an OpenLayers map centered on Ulan Bator:
+* When you now reload the [{{ book.exerciseUrl }}/ol-example.html]({{ book.exerciseUrl }}/ol-example.html) URL, you should see an OpenLayers map centered on Ulan Bator:
 
 ![A very basic OpenLayers map](hello-ol.png)
 

--- a/src/map-component/basic-example.md
+++ b/src/map-component/basic-example.md
@@ -57,7 +57,7 @@ We want to have a look at a fully working example first.
 </html>
 ```
 
-* Verify that {{ book.exerciseUrl }}/map.html loads in your browser and looks like the picture below.
+* Verify that [{{ book.exerciseUrl }}/map.html]({{ book.exerciseUrl }}/map.html) loads in your browser and looks like the picture below.
 
 ![A map component in a fullscreen viewport](map.png)
 

--- a/src/other/overview-map.md
+++ b/src/other/overview-map.md
@@ -186,7 +186,7 @@ Ext.onReady(function(){
 </html>
 ```
 
-* If you open this file in a browser ({{ book.exerciseUrl }}/map.html), the application should look like in the following image, but you should also be able to see popups when hovering over a map location:
+* If you open this file in a browser ([{{ book.exerciseUrl }}/map.html]({{ book.exerciseUrl }}/map.html)), the application should look like in the following image, but you should also be able to see popups when hovering over a map location:
 
 ![Our starting point](../feature-grid/after.png)
 

--- a/src/other/popups.md
+++ b/src/other/popups.md
@@ -154,7 +154,7 @@ Ext.onReady(function(){
 </html>
 ```
 
-* If you open this file in a browser ({{ book.exerciseUrl }}/map.html), the application should look like in the following image:
+* If you open this file in a browser ([{{ book.exerciseUrl }}/map.html]({{ book.exerciseUrl }}/map.html)), the application should look like in the following image:
 
 ![Our starting point](../feature-grid/after.png)
 


### PR DESCRIPTION
When not using markdown link format the result looks like http://localhost:4000/examples\/my-file.html
With this change it should look like  http://localhost:4000/examples/my-file.html
